### PR TITLE
Async AdyenCheckout, better redirecting

### DIFF
--- a/src/app/paymentSlice.js
+++ b/src/app/paymentSlice.js
@@ -4,7 +4,8 @@ export const slice = createSlice({
   name: "payment",
   initialState: {
     error: "",
-    sessionAndOrderRef: null,
+    session: null,
+    orderRef: null,
     paymentDataStoreRes: null,
     config: {
       storePaymentMethod: true,
@@ -34,7 +35,7 @@ export const slice = createSlice({
       if (status >= 300) {
         state.error = res;
       } else {
-        state.sessionAndOrderRef = res;
+        [state.session, state.orderRef] = res;
       }
     },
     paymentDataStore: (state, action) => {

--- a/src/features/payment/Payment.js
+++ b/src/features/payment/Payment.js
@@ -28,7 +28,7 @@ class CheckoutContainer extends React.Component {
     this.props.initiateCheckout(this.props.type);
   }
 
-  componentDidUpdate(prevProps) {
+  async componentDidUpdate(prevProps) {
     const { sessionAndOrderRef, config, error } = this.props.payment;
     if (error && error !== prevProps.payment.error) {
       window.location.href = `/status/error?reason=${error}`;
@@ -42,10 +42,8 @@ class CheckoutContainer extends React.Component {
       onError : ((err, _) => {this.processPaymentResponse(err);}),      
     }
 
-    // @ts-ignore
-    // eslint-disable-next-line no-undef
-    this.checkout = new AdyenCheckout(configWithSession)
-      .then(checkout => { checkout.create(this.props.type).mount(this.paymentContainer.current);});
+    const checkout = await AdyenCheckout(configWithSession);
+    checkout.create(this.props.type).mount(this.paymentContainer.current);
   }
 
   processPaymentResponse(paymentRes) {

--- a/src/features/payment/Payment.js
+++ b/src/features/payment/Payment.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { connect } from "react-redux";
-import { useParams } from "react-router-dom";
+import { useParams, withRouter } from "react-router-dom";
 import AdyenCheckout from "@adyen/adyen-web";
 import "@adyen/adyen-web/dist/adyen.css";
 import { initiateCheckout } from "../../app/paymentSlice";
@@ -31,7 +31,7 @@ class CheckoutContainer extends React.Component {
   async componentDidUpdate(prevProps) {
     const { session, config, error } = this.props.payment;
     if (error && error !== prevProps.payment.error) {
-      window.location.href = `/status/error?reason=${error}`;
+      this.props.history.replace(`/status/error?reason=${error}`);
       return;
     }
 
@@ -49,17 +49,17 @@ class CheckoutContainer extends React.Component {
   processPaymentResponse(paymentRes) {
     switch (paymentRes.resultCode) {
       case "Authorised":
-        window.location.href = "/status/success";
+        this.props.history.replace("/status/success");
         break;
       case "Pending":
       case "Received":
-        window.location.href = "/status/pending";
+        this.props.history.replace("/status/pending");
         break;
       case "Refused":
-        window.location.href = "/status/failed";
+        this.props.history.replace("/status/failed");
         break;
       default:
-        window.location.href = "/status/error";
+        this.props.history.replace("/status/error");
         break;
     }
   }
@@ -79,4 +79,4 @@ const mapStateToProps = (state) => ({
 
 const mapDispatchToProps = { initiateCheckout };
 
-export const ConnectedCheckoutContainer = connect(mapStateToProps, mapDispatchToProps)(CheckoutContainer);
+export const ConnectedCheckoutContainer = connect(mapStateToProps, mapDispatchToProps)(withRouter(CheckoutContainer));

--- a/src/features/payment/Payment.js
+++ b/src/features/payment/Payment.js
@@ -29,7 +29,7 @@ class CheckoutContainer extends React.Component {
   }
 
   async componentDidUpdate(prevProps) {
-    const { sessionAndOrderRef, config, error } = this.props.payment;
+    const { session, config, error } = this.props.payment;
     if (error && error !== prevProps.payment.error) {
       window.location.href = `/status/error?reason=${error}`;
       return;
@@ -37,7 +37,7 @@ class CheckoutContainer extends React.Component {
 
     const configWithSession = {
       ...config,
-      session : sessionAndOrderRef[0],
+      session,
       onPaymentCompleted : ((res, _) => {this.processPaymentResponse(res);}),
       onError : ((err, _) => {this.processPaymentResponse(err);}),      
     }

--- a/src/features/redirect/Redirect.js
+++ b/src/features/redirect/Redirect.js
@@ -27,17 +27,17 @@ class RedirectContainer extends React.Component {
   processPaymentResponse(paymentRes) {
     switch (paymentRes.resultCode) {
       case "Authorised":
-        window.location.href = "/status/success";
+        this.props.history.replace("/status/success");
         break;
       case "Pending":
       case "Received":
-        window.location.href = "/status/pending";
+        this.props.history.replace("/status/pending");
         break;
       case "Refused":
-        window.location.href = "/status/failed";
+        this.props.history.replace("/status/failed");
         break;
       default:
-        window.location.href = "/status/error";
+        this.props.history.replace("/status/error");
         break;
     }
   }

--- a/src/features/redirect/Redirect.js
+++ b/src/features/redirect/Redirect.js
@@ -7,7 +7,7 @@ import { withRouter } from 'react-router-dom';
 
 // This class is used to finalize redirect flows for some payment methods
 class RedirectContainer extends React.Component {
-  componentDidMount() { 
+  async componentDidMount() {
     const { config } = this.props.payment;
 
     const sessionId = new URLSearchParams(this.props.location.search).get('sessionId');
@@ -19,12 +19,9 @@ class RedirectContainer extends React.Component {
       onPaymentCompleted : ((res, _) => {this.processPaymentResponse(res);}),
       onError : ((err, _) => {this.processPaymentResponse(err);}),      
     }
-    
-    // @ts-ignore
-    // eslint-disable-next-line no-undef
-    this.checkout = new AdyenCheckout(configWithSession).then((checkout) => {
-      checkout.submitDetails({details: {redirectResult}}); // we finalize the redirect flow with the reeived payload
-    });
+
+    const checkout = await AdyenCheckout(configWithSession);
+    checkout.submitDetails({details: {redirectResult}}); // we finalize the redirect flow with the reeived payload
   }
 
   processPaymentResponse(paymentRes) {


### PR DESCRIPTION
This pr implements three small improvements

1. `AdyenCheckout` is initialised with async/await.
2. `sessionAndOrderRef` in the state is split up into `session` and `orderRef`. Right now only session is used in other places.
3. Use `props.history.replace(...)` instead of `window.location.href = ...`. This uses react-router's own routing and does not require an actual redirect in many cases. (This fixes #9)