### PR TITLE
Rename env variables

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [16.x]
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Build image (application)
         run: docker build -t test-image:latest .
       - name: Start container (application)
-        run: docker run --rm -d --name test-image -p 8080:8080 -e REACT_APP_ADYEN_API_KEY="${{ secrets.ADYEN_API_KEY }}" -e REACT_APP_ADYEN_MERCHANT_ACCOUNT=${{ secrets.ADYEN_MERCHANT_ACCOUNT }} -e REACT_APP_ADYEN_CLIENT_KEY=${{ secrets.ADYEN_CLIENT_KEY }} -e REACT_APP_ADYEN_HMAC_KEY=${{ secrets.ADYEN_HMAC_KEY }} test-image:latest
+        run: docker run --rm -d --name test-image -p 8080:8080 -e ADYEN_API_KEY="${{ secrets.ADYEN_API_KEY }}" -e ADYEN_MERCHANT_ACCOUNT=${{ secrets.ADYEN_MERCHANT_ACCOUNT }} -e REACT_APP_ADYEN_CLIENT_KEY=${{ secrets.ADYEN_CLIENT_KEY }} -e ADYEN_HMAC_KEY=${{ secrets.ADYEN_HMAC_KEY }} test-image:latest
       - name: Run testing suite
         run: docker run --rm --name adyen-testing-suite --network host ghcr.io/adyen-examples/adyen-testing-suite:main
 

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,8 +1,8 @@
 tasks:
 - init: npm install
   command: |
-        if [ -z ${ADYEN_HMAC_KEY+x} ] || [[ -z ${ADYEN_API_KEY+x} ]] || [[ -z ${ADYEN_CLIENT_KEY+x} ]] || [[ -z ${ADYEN_MERCHANT_ACCOUNT+x} ]]; then
-            echo "Expected environment variables not found. Please set the ADYEN_HMAC_KEY, ADYEN_API_KEY, ADYEN_CLIENT_KEY, ADYEN_MERCHANT_ACCOUNT environment variables and rerun session https://gitpod.io/variables."
+        if [ -z ${ADYEN_HMAC_KEY+x} ] || [[ -z ${ADYEN_API_KEY+x} ]] || [[ -z ${REACT_APP_ADYEN_CLIENT_KEY+x} ]] || [[ -z ${ADYEN_MERCHANT_ACCOUNT+x} ]]; then
+            echo "Expected environment variables not found. Please set the ADYEN_HMAC_KEY, ADYEN_API_KEY, REACT_APP_ADYEN_CLIENT_KEY, ADYEN_MERCHANT_ACCOUNT environment variables and rerun session https://gitpod.io/variables."
         else
             npm run server
         fi

--- a/README.md
+++ b/README.md
@@ -59,10 +59,13 @@ npm install
 1. Create a `./.env` file with your [API key](https://docs.adyen.com/user-management/how-to-get-the-api-key), [Client Key](https://docs.adyen.com/user-management/client-side-authentication) - Remember to add `http://localhost:3000` as an origin for client key, and merchant account name (all credentials are in string format):
 
 ```
-REACT_APP_ADYEN_API_KEY="your_API_key_here"
-REACT_APP_ADYEN_MERCHANT_ACCOUNT="your_merchant_account_here"
+# server-side env variables
+ADYEN_API_KEY="your_API_key_here"
+ADYEN_MERCHANT_ACCOUNT="your_merchant_account_here"
+ADYEN_HMAC_KEY=yourNotificationSetupHMACkey
+
+# client-side env variables: using REACT_APP prefix to be included in the REACT build 
 REACT_APP_ADYEN_CLIENT_KEY="your_client_key_here"
-REACT_APP_ADYEN_HMAC_KEY=yourNotificationSetupHMACkey
 ```
 
 2. Build & Start the server:

--- a/server.js
+++ b/server.js
@@ -23,7 +23,7 @@ dotenv.config({
 
 // Adyen Node.js API library boilerplate (configuration, etc.)
 const config = new Config();
-config.apiKey = process.env.REACT_APP_ADYEN_API_KEY;
+config.apiKey = process.env.ADYEN_API_KEY;
 const client = new Client({ config });
 client.setEnvironment("TEST");
 const checkout = new CheckoutAPI(client);
@@ -38,8 +38,8 @@ const determineHostUrl = (req) => {
     "x-forwarded-host": forwardedHost,
   } = req.headers
 
-  if (process.env.REACT_APP_ADYEN_RETURN_URL) {
-    return process.env.REACT_APP_ADYEN_RETURN_URL;
+  if (process.env.ADYEN_RETURN_URL) {
+    return process.env.ADYEN_RETURN_URL;
   }
 
   if (forwardedProto && forwardedHost) {
@@ -69,7 +69,7 @@ app.post("/api/sessions", async (req, res) => {
       countryCode: "NL",
       amount: { currency: "EUR", value: 10000 }, // value is 100€ in minor units
       reference: orderRef, // required
-      merchantAccount: process.env.REACT_APP_ADYEN_MERCHANT_ACCOUNT, // required
+      merchantAccount: process.env.ADYEN_MERCHANT_ACCOUNT, // required
       returnUrl: `${determineHostUrl(req)}/redirect?orderRef=${orderRef}`, // required for 3ds2 redirect flow
       // set lineItems required for some payment methods (ie Klarna)
       lineItems: [
@@ -98,7 +98,7 @@ app.post("/api/cancelOrRefundPayment", async (req, res) => {
   console.log("/api/cancelOrRefundPayment orderRef: " + req.query.orderRef);
   // Create the payload for cancelling payment
   const payload = {
-    merchantAccount: process.env.REACT_APP_ADYEN_MERCHANT_ACCOUNT, // required
+    merchantAccount: process.env.ADYEN_MERCHANT_ACCOUNT, // required
     reference: uuid(),
   };
 
@@ -125,7 +125,7 @@ app.post("/api/webhooks/notifications", async (req, res) => {
   const notificationRequestItem = notificationRequestItems[0].NotificationRequestItem;
   console.log(notificationRequestItem);
   
-  if (!validator.validateHMAC(notificationRequestItem, process.env.REACT_APP_ADYEN_HMAC_KEY)) {
+  if (!validator.validateHMAC(notificationRequestItem, process.env.ADYEN_HMAC_KEY)) {
     // invalid hmac: webhook cannot be accepted
     res.status(401).send('Invalid HMAC signature');
     return;

--- a/server.js
+++ b/server.js
@@ -38,10 +38,6 @@ const determineHostUrl = (req) => {
     "x-forwarded-host": forwardedHost,
   } = req.headers
 
-  if (process.env.ADYEN_RETURN_URL) {
-    return process.env.ADYEN_RETURN_URL;
-  }
-
   if (forwardedProto && forwardedHost) {
     if (forwardedProto.includes(",")) {
       [forwardedProto,] = forwardedProto.split(",")


### PR DESCRIPTION
Rename server-side environment variables to be consistent with all other sample apps
```
ADYEN_API_KEY=
ADYEN_MERCHANT_ACCOUNT=
ADYEN_HMAC_KEY=
```
while keeping client-side environment variables as before (prefix `REACT_APP` is necessary to include variable in the React build)
```
REACT_APP_ADYEN_CLIENT_KEY=
```

Fix #142 

