### PR TITLE
Webhook processing: 202 response with empty body

### DIFF
--- a/server.js
+++ b/server.js
@@ -157,7 +157,8 @@ app.post("/api/webhooks/notifications", async (req, res) => {
     }
   }
 
-  res.send('[accepted]');
+  // acknowledge event has been consumed
+  res.status(202).send(); // Send a 202 response with an empty body
   
 });
 


### PR DESCRIPTION
The latest approach to accepting webhooks requires sending the response code `202` and an empty response body.

This PR updates all webhook handlers to implement the new approach.