### PR TITLE
Upgrade to iDEAL 2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "adyen-react-online-payments",
       "version": "0.1.0",
       "dependencies": {
-        "@adyen/adyen-web": "5.60.0",
+        "@adyen/adyen-web": "5.68.0",
         "@adyen/api-library": "^19.2.0",
         "@reduxjs/toolkit": "^2.0.1",
         "dotenv": "^16.0.3",
@@ -38,14 +38,14 @@
       "dev": true
     },
     "node_modules/@adyen/adyen-web": {
-      "version": "5.60.0",
-      "resolved": "https://registry.npmjs.org/@adyen/adyen-web/-/adyen-web-5.60.0.tgz",
-      "integrity": "sha512-RAtpKKGF9vJYFvahv7qMtCIH3mLxkBOYOntzXtivOMwgPYeXGFNB/3M6gXKC2f6IgiHrqES6t7K8UvzTXFmVZg==",
+      "version": "5.68.0",
+      "resolved": "https://registry.npmjs.org/@adyen/adyen-web/-/adyen-web-5.68.0.tgz",
+      "integrity": "sha512-zWNjWgfFuUxMqNcuFKcXmiT/RfY3Zkd9qU1v910psTeHMWRBFpqtNM1YXf+zd46YeacF5CJMduxQ1aHs+DgNiQ==",
       "dependencies": {
         "@babel/runtime": "^7.15.4",
         "@babel/runtime-corejs3": "^7.20.1",
         "@types/applepayjs": "14.0.6",
-        "@types/googlepay": "^0.7.0",
+        "@types/googlepay": "0.7.6",
         "classnames": "^2.3.1",
         "core-js-pure": "^3.25.3",
         "preact": "10.13.2"
@@ -4208,9 +4208,9 @@
       }
     },
     "node_modules/@types/googlepay": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@types/googlepay/-/googlepay-0.7.0.tgz",
-      "integrity": "sha512-jC7ViexJeV8LlTKLiUBfNs5GICbm0PYsm5Y30JCEBkreY0bMNA+F4KnTEz+WtqBTRldTAxKBKqRstlOUFpW+dA=="
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/@types/googlepay/-/googlepay-0.7.6.tgz",
+      "integrity": "sha512-5003wG+qvf4Ktf1hC9IJuRakNzQov00+Xf09pAWGJLpdOjUrq0SSLCpXX7pwSeTG9r5hrdzq1iFyZcW7WVyr4g=="
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.6",
@@ -19390,14 +19390,14 @@
       "dev": true
     },
     "@adyen/adyen-web": {
-      "version": "5.60.0",
-      "resolved": "https://registry.npmjs.org/@adyen/adyen-web/-/adyen-web-5.60.0.tgz",
-      "integrity": "sha512-RAtpKKGF9vJYFvahv7qMtCIH3mLxkBOYOntzXtivOMwgPYeXGFNB/3M6gXKC2f6IgiHrqES6t7K8UvzTXFmVZg==",
+      "version": "5.68.0",
+      "resolved": "https://registry.npmjs.org/@adyen/adyen-web/-/adyen-web-5.68.0.tgz",
+      "integrity": "sha512-zWNjWgfFuUxMqNcuFKcXmiT/RfY3Zkd9qU1v910psTeHMWRBFpqtNM1YXf+zd46YeacF5CJMduxQ1aHs+DgNiQ==",
       "requires": {
         "@babel/runtime": "^7.15.4",
         "@babel/runtime-corejs3": "^7.20.1",
         "@types/applepayjs": "14.0.6",
-        "@types/googlepay": "^0.7.0",
+        "@types/googlepay": "0.7.6",
         "classnames": "^2.3.1",
         "core-js-pure": "^3.25.3",
         "preact": "10.13.2"
@@ -22106,9 +22106,9 @@
       }
     },
     "@types/googlepay": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@types/googlepay/-/googlepay-0.7.0.tgz",
-      "integrity": "sha512-jC7ViexJeV8LlTKLiUBfNs5GICbm0PYsm5Y30JCEBkreY0bMNA+F4KnTEz+WtqBTRldTAxKBKqRstlOUFpW+dA=="
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/@types/googlepay/-/googlepay-0.7.6.tgz",
+      "integrity": "sha512-5003wG+qvf4Ktf1hC9IJuRakNzQov00+Xf09pAWGJLpdOjUrq0SSLCpXX7pwSeTG9r5hrdzq1iFyZcW7WVyr4g=="
     },
     "@types/graceful-fs": {
       "version": "4.1.6",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "@adyen/adyen-web": "5.60.0",
+    "@adyen/adyen-web": "5.68.0",
     "@adyen/api-library": "^19.2.0",
     "@reduxjs/toolkit": "^2.0.1",
     "dotenv": "^16.0.3",


### PR DESCRIPTION
Support iDEAL 2.0.

Changes required: update to `Drop-in v5.68.0`

### Note 

- on **TEST** the iDEAL payment method in the Customer Area must be updated to use the `AdyenIdeal` acquirer
- on **LIVE** no changes are required in the Customer Area